### PR TITLE
Product Searching v1 -- Searchbar behaviors & handle fetching products by search key

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "redux-persist": "^6.0.0",
     "slick-carousel": "^1.8.1",
     "typescript": "5.1.3",
+    "usehooks-ts": "^2.9.1",
     "yup": "^1.2.0"
   },
   "devDependencies": {

--- a/src/app/tim-kiem/[searchKey]/page.tsx
+++ b/src/app/tim-kiem/[searchKey]/page.tsx
@@ -1,9 +1,0 @@
-import React from 'react';
-
-const SearchPage = ({ params }: { params : { searchKey: string }}) => {
-  return (
-    <div>SearchPage</div>
-  );
-}
-
-export default SearchPage;

--- a/src/app/tim-kiem/loading.tsx
+++ b/src/app/tim-kiem/loading.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import LoadingPage from '@components/Common/Display/LoadingPage';
+
+const Loading = () => {
+    return (
+        <LoadingPage />
+    );
+};
+
+export default Loading;

--- a/src/app/tim-kiem/page.tsx
+++ b/src/app/tim-kiem/page.tsx
@@ -1,0 +1,47 @@
+import React, { Suspense } from 'react';
+
+import { getProductsCustom } from 'utils/get-products';
+import Loading from './loading';
+import ResultsPage from '@components/Common/Searching/ResultsPage';
+import {
+    FOUND_CODE,
+    NOTFOUND_ERROR_CODE,
+    SERVER_ERROR_CODE,
+} from '@constants/errorCode';
+import { ProductSearchingStatus } from '@interfaces/product';
+
+const SearchPage = async ({ searchParams }: { searchParams: { search?: string } }) => {
+    const searchQuery = searchParams.search ?? '';
+
+    const decodeKeyword = decodeURIComponent(searchQuery);
+
+    const searchData: ProductSearchingStatus = await getProductsCustom(searchQuery)
+        .then((res) => {
+            return {
+                data: res,
+                messageStatusCode: FOUND_CODE,
+            };
+        })
+        .catch((err) => {
+            if (err.response.status === 404) {
+                return {
+                    data: null,
+                    messageStatusCode: NOTFOUND_ERROR_CODE,
+                };
+            } else {
+                return {
+                    data: null,
+                    messageStatusCode: SERVER_ERROR_CODE,
+                };
+            }
+        });
+    console.log(searchData);
+
+    return (
+        <Suspense fallback={<Loading />}>
+            <ResultsPage searchData={searchData} keyword={decodeKeyword} />
+        </Suspense>
+    );
+};
+
+export default SearchPage;

--- a/src/components/Common/Display/LoadingPage.tsx
+++ b/src/components/Common/Display/LoadingPage.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import React from 'react';
+
+import Box from '@mui/material/Box';
+import Container from '@mui/material/Container';
+import MoonLoader from 'react-spinners/MoonLoader';
+import Typography from '@mui/material/Typography';
+import Stack from '@mui/material/Stack';
+import { useTheme } from '@mui/material/styles';
+
+const LoadingPage = () => {
+    const theme = useTheme();
+
+    return (
+        <Box marginTop="20px">
+            <Container maxWidth="lg">
+                <Stack
+                    sx={{
+                        minHeight: '80vh',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                    }}
+                    spacing={3}
+                >
+                    <MoonLoader
+                        color={theme.color.red}
+                        speedMultiplier={0.75}
+                        size={60}
+                    />
+                    <Typography variant="subtitle1">Đang tải ...</Typography>
+                </Stack>
+            </Container>
+        </Box>
+    );
+};
+
+export default LoadingPage;

--- a/src/components/Common/Home/FeaturedSection.tsx
+++ b/src/components/Common/Home/FeaturedSection.tsx
@@ -3,7 +3,7 @@
 import React, { useState, MouseEvent, FC } from 'react';
 
 import List from '@mui/material/List';
-import {styled} from '@mui/material';
+import { styled } from '@mui/material';
 import ListItemButton from '@mui/material/ListItemButton';
 import ListItemText from '@mui/material/ListItemText';
 import { useTheme } from '@mui/material';
@@ -59,196 +59,192 @@ const FeaturedSection: FC<ProductsListProps> = ({ initialData }) => {
     };
 
     return (
-        <>
-            <Box>
-                <Box
-                    sx={{
-                        margin: '20px 0px',
-                        justifyContent: 'center',
-                        alignItems: 'center',
-                        display: 'flex',
-                    }}
-                >
-                    <Stack spacing={0} sx={{ alignItems: 'center' }}>
-                        <FormControl
-                            variant="standard"
-                            sx={{
-                                display: { sm: 'none', xs: 'flex' },
-                                minWidth: '120px',
-                            }}
+        <Box>
+            <Box
+                sx={{
+                    margin: '20px 0px',
+                    justifyContent: 'center',
+                    alignItems: 'center',
+                    display: 'flex',
+                }}
+            >
+                <Stack spacing={0} sx={{ alignItems: 'center' }}>
+                    <FormControl
+                        variant="standard"
+                        sx={{
+                            display: { sm: 'none', xs: 'flex' },
+                            minWidth: '120px',
+                        }}
+                    >
+                        <InputLabel id="select-tag">Tag</InputLabel>
+                        <Select labelId="select-tag" value={selectedTag} onChange={handleTagChange}>
+                            <MenuItem value="latest">
+                                <Typography
+                                    variant="h6"
+                                    sx={{ fontWeight: 'bold', fontSize: '15px' }}
+                                >
+                                    Sản phẩm mới nhất
+                                </Typography>
+                            </MenuItem>
+                            <MenuItem value="best-selling">
+                                <Typography
+                                    variant="h6"
+                                    sx={{ fontWeight: 'bold', fontSize: '15px' }}
+                                >
+                                    Bán chạy nhất
+                                </Typography>
+                            </MenuItem>
+                            <MenuItem value="featured">
+                                <Typography
+                                    variant="h6"
+                                    sx={{ fontWeight: 'bold', fontSize: '15px' }}
+                                >
+                                    Sản phẩm nổi bật
+                                </Typography>
+                            </MenuItem>
+                        </Select>
+                    </FormControl>
+                    <List
+                        component="a"
+                        sx={{
+                            display: { sm: 'flex', xs: 'none' },
+                            flexDirection: 'row',
+                            color: theme.color.gray,
+                            textTransform: 'uppercase',
+                        }}
+                    >
+                        <Divider
+                            flexItem
+                            orientation="vertical"
+                            sx={{ mx: 0.5, my: 1, width: '1px' }}
+                        />
+                        <StyledListItemButton
+                            selected={selectedTag === 'latest'}
+                            onClick={(event) => handleTagSelect(event, 'latest')}
                         >
-                            <InputLabel id="select-tag">Tag</InputLabel>
-                            <Select
-                                labelId="select-tag"
-                                value={selectedTag}
-                                onChange={handleTagChange}
-                            >
-                                <MenuItem value="latest">
+                            <ListItemText
+                                disableTypography
+                                primary={
                                     <Typography
                                         variant="h6"
-                                        sx={{ fontWeight: 'bold', fontSize: '15px' }}
+                                        sx={{ fontWeight: 'bold', fontSize: '16px' }}
                                     >
                                         Sản phẩm mới nhất
                                     </Typography>
-                                </MenuItem>
-                                <MenuItem value="best-selling">
+                                }
+                            />
+                        </StyledListItemButton>
+                        <Divider
+                            flexItem
+                            orientation="vertical"
+                            sx={{ mx: 0.5, my: 1, width: '1px' }}
+                        />
+                        <StyledListItemButton
+                            selected={selectedTag === 'best-selling'}
+                            onClick={(event) => handleTagSelect(event, 'best-selling')}
+                        >
+                            <ListItemText
+                                disableTypography
+                                primary={
                                     <Typography
                                         variant="h6"
-                                        sx={{ fontWeight: 'bold', fontSize: '15px' }}
+                                        sx={{ fontWeight: 'bold', fontSize: '16px' }}
                                     >
                                         Bán chạy nhất
                                     </Typography>
-                                </MenuItem>
-                                <MenuItem value="featured">
+                                }
+                            />
+                        </StyledListItemButton>
+                        <Divider
+                            flexItem
+                            orientation="vertical"
+                            sx={{ mx: 0.5, my: 1, width: '1px' }}
+                        />
+                        <StyledListItemButton
+                            selected={selectedTag === 'featured'}
+                            onClick={(event) => handleTagSelect(event, 'featured')}
+                        >
+                            <ListItemText
+                                disableTypography
+                                primary={
                                     <Typography
                                         variant="h6"
-                                        sx={{ fontWeight: 'bold', fontSize: '15px' }}
+                                        sx={{ fontWeight: 'bold', fontSize: '16px' }}
                                     >
                                         Sản phẩm nổi bật
                                     </Typography>
-                                </MenuItem>
-                            </Select>
-                        </FormControl>
-                        <List
-                            component="a"
-                            sx={{
-                                display: { sm: 'flex', xs: 'none' },
-                                flexDirection: 'row',
-                                color: theme.color.gray,
-                                textTransform: 'uppercase',
-                            }}
-                        >
-                            <StyledListItemButton
-                                selected={selectedTag === 'latest'}
-                                onClick={(event) => handleTagSelect(event, 'latest')}
-                            >
-                                <ListItemText
-                                    disableTypography
-                                    primary={
-                                        <Typography
-                                            variant="h6"
-                                            sx={{ fontWeight: 'bold', fontSize: '16px' }}
-                                        >
-                                            Sản phẩm mới nhất
-                                        </Typography>
-                                    }
-                                />
-                            </StyledListItemButton>
-                            <Divider
-                                flexItem
-                                orientation="vertical"
-                                sx={{ mx: 0.5, my: 1, width: '1px' }}
+                                }
                             />
-                            <StyledListItemButton
-                                selected={selectedTag === 'best-selling'}
-                                onClick={(event) => handleTagSelect(event, 'best-selling')}
-                            >
-                                <ListItemText
-                                    disableTypography
-                                    primary={
-                                        <Typography
-                                            variant="h6"
-                                            sx={{ fontWeight: 'bold', fontSize: '16px' }}
-                                        >
-                                            Bán chạy nhất
-                                        </Typography>
-                                    }
-                                />
-                            </StyledListItemButton>
-                            <Divider
-                                flexItem
-                                orientation="vertical"
-                                sx={{ mx: 0.5, my: 1, width: '1px' }}
-                            />
-                            <StyledListItemButton
-                                selected={selectedTag === 'featured'}
-                                onClick={(event) => handleTagSelect(event, 'featured')}
-                            >
-                                <ListItemText
-                                    disableTypography
-                                    primary={
-                                        <Typography
-                                            variant="h6"
-                                            sx={{ fontWeight: 'bold', fontSize: '16px' }}
-                                        >
-                                            Sản phẩm nổi bật
-                                        </Typography>
-                                    }
-                                />
-                            </StyledListItemButton>
-                            <Divider
-                                flexItem
-                                orientation="vertical"
-                                sx={{ mx: 0.5, my: 1, width: '1px' }}
-                            />
-                        </List>
-
+                        </StyledListItemButton>
                         <Divider
-                            component="div"
-                            sx={{
-                                width: '100%',
-                                height: '2px',
-                                marginTop: 0,
-                                background: `linear-gradient(to right, lightGray, ${theme.color.gray} , ${theme.color.red}, ${theme.color.gray}, lightGray)`,
-                            }}
+                            flexItem
+                            orientation="vertical"
+                            sx={{ mx: 0.5, my: 1, width: '1px' }}
                         />
-                    </Stack>
-                </Box>
-                <Box
-                    sx={{
-                        display: 'flex',
-                        justifyContent: 'center',
-                        alignItems: 'center',
-                        marginTop: '10px',
-                    }}
-                >
-                    <Box sx={{ width: '1200px' }}>
+                    </List>
+
+                    <Divider
+                        component="div"
+                        sx={{
+                            width: '100%',
+                            height: '2px',
+                            marginTop: 0,
+                            background: `linear-gradient(to right, lightGray, ${theme.color.gray} , ${theme.color.red}, ${theme.color.gray}, lightGray)`,
+                        }}
+                    />
+                </Stack>
+            </Box>
+            <Box
+                sx={{
+                    display: 'flex',
+                    justifyContent: 'center',
+                    alignItems: 'center',
+                    marginTop: '10px',
+                }}
+            >
+                <Box sx={{ width: '1200px' }}>
+                    <Box
+                        sx={{
+                            maxWidth: '100%',
+                            borderRadius: '5px',
+                        }}
+                    >
                         <Box
                             sx={{
-                                maxWidth: '100%',
-                                borderRadius: '5px',
+                                padding: { lg: '15px 0px 15px 0px', xs: '0px 10px 0px 10px' },
                             }}
                         >
-                            <Box
-                                sx={{
-                                    padding: { lg: '15px 0px 15px 0px', xs: '0px 10px 0px 10px' },
-                                }}
-                            >
-                                <Box
-                                    sx={{ display: 'flex', justifyContent: { xs: 'space-around' } }}
+                            <Box sx={{ display: 'flex', justifyContent: { xs: 'space-around' } }}>
+                                <Grid
+                                    container
+                                    sx={{
+                                        width: '100%',
+                                        display: 'flex',
+                                        justifyContent: {
+                                            sm: 'flex-start',
+                                            xs: 'space-around',
+                                        },
+                                    }}
+                                    spacing={5}
                                 >
-                                    <Grid
-                                        container
-                                        sx={{
-                                            width: '100%',
-                                            display: 'flex',
-                                            justifyContent: {
-                                                sm: 'flex-start',
-                                                xs: 'space-around',
-                                            },
-                                        }}
-                                        spacing={5}
-                                    >
-                                        {initialData.map((product) => (
-                                            <Grid
-                                                sx={{ padding: '12.5px' }}
-                                                xs={6}
-                                                lg={3}
-                                                md={4}
-                                                key={product.id}
-                                            >
-                                                <CardComponent initialData={product} />
-                                            </Grid>
-                                        ))}
-                                        ;
-                                    </Grid>
-                                </Box>
+                                    {initialData.map((product) => (
+                                        <Grid
+                                            sx={{ padding: '12.5px' }}
+                                            xs={6}
+                                            lg={3}
+                                            md={4}
+                                            key={product.id}
+                                        >
+                                            <CardComponent initialData={product} />
+                                        </Grid>
+                                    ))}
+                                </Grid>
                             </Box>
                         </Box>
                     </Box>
                 </Box>
             </Box>
-        </>
+        </Box>
     );
 };
 

--- a/src/components/Common/Home/HomePage.tsx
+++ b/src/components/Common/Home/HomePage.tsx
@@ -16,8 +16,9 @@ import { Paging } from '@models/Common';
 import { useAppDispatch, useAppSelector } from '@store/store';
 import { getAllProduct } from '@store/slices/productSlice';
 
-import { getThumbnail } from 'utils';
+import { formatProductLabel, getThumbnail } from 'utils';
 import { ProductLabel } from '@interfaces/product';
+import LoadingSection from '../Display/LoadingSection';
 
 const HomePage = () => {
     const dispatch = useAppDispatch();
@@ -32,15 +33,7 @@ const HomePage = () => {
     }, [searchProduct]);
 
     useEffect(() => {
-        const productData = products.data.slice(0, 4).map((product) => {
-            return {
-                id: product._id ?? '',
-                name: product.name ?? '',
-                category: product.category?.name ?? '',
-                price: product.variations[0].price,
-                image: getThumbnail(product.generalImages),
-            };
-        });
+        const productData = formatProductLabel(products).slice(0, 4);
 
         setNewestProducts(productData);
 
@@ -52,7 +45,11 @@ const HomePage = () => {
         <ShopServicesComponent />
         <Container maxWidth="lg">
                 <Stack spacing={3}>
-                    <FeaturedSection initialData={newestProducts} />
+                    {isLoading ? (
+                        <LoadingSection isLoading={isLoading} />
+                    ) : (
+                        <FeaturedSection initialData={newestProducts} />
+                    )}
                     <BrandCategoryCompoment />
                     <Box sx={{ maxWidth: { lg: '100%', xs: '100%' } }}>
                         <Image

--- a/src/components/Common/Products/Products.tsx
+++ b/src/components/Common/Products/Products.tsx
@@ -51,8 +51,6 @@ const Products: FC<ProductsPageProps> = ({ className }) => {
             };
         });
 
-        console.log(productData);
-
         setCurrentProducts(productData);
     }, [products]);
 

--- a/src/components/Common/Searching/CurrentSearches.tsx
+++ b/src/components/Common/Searching/CurrentSearches.tsx
@@ -1,0 +1,200 @@
+import React, { FC, useEffect, useRef, useState } from 'react';
+import { useRouter } from 'next/navigation';
+
+import { useOnClickOutside } from 'usehooks-ts';
+
+import Popper, { PopperProps } from '@mui/material/Popper';
+import Paper from '@mui/material/Paper';
+import MenuList from '@mui/material/MenuList';
+import MenuItem from '@mui/material/MenuItem';
+import ListItemIcon from '@mui/material/ListItemIcon';
+import ListItemText from '@mui/material/ListItemText';
+import IconButton from '@mui/material/IconButton';
+import Stack from '@mui/material/Stack';
+import Button from '@mui/material/Button';
+import Typography from '@mui/material/Typography';
+
+import AccessTimeIcon from '@mui/icons-material/AccessTime';
+import CloseIcon from '@mui/icons-material/Close';
+import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
+
+import { PulseLoader } from 'react-spinners';
+
+import { ProductLabel } from '@interfaces/product';
+
+import { useAppSelector } from '@store/store';
+
+import { currencyFormat, formatProductLabel } from 'utils';
+import Box from '@mui/material/Box';
+import Image from 'next/image';
+
+interface RecentSearchValueProps {
+    onClose(): void;
+    getHistoryKey(searched: string): void;
+    recentSearches: string[];
+    removeItem(searchTerm: string): void;
+}
+
+const CurrentSearches: FC<RecentSearchValueProps & PopperProps> = ({
+    anchorEl,
+    open,
+    onClose,
+    recentSearches,
+    removeItem,
+    getHistoryKey,
+}) => {
+    const router = useRouter();
+
+    const paperRef = useRef<HTMLDivElement>(null);
+
+    const [currentProducts, setCurrentProducts] = useState<ProductLabel[]>([]);
+
+    const { products, isLoading } = useAppSelector((state) => state.product);
+
+    useEffect(() => {
+        const productLabels = formatProductLabel(products);
+
+        setCurrentProducts(productLabels);
+    }, [products, isLoading]);
+
+    useOnClickOutside(paperRef, onClose);
+    if (!anchorEl) return null;
+
+    console.log(products);
+
+    return (
+        <Popper open={open} anchorEl={anchorEl} disablePortal placement="bottom-start">
+            <Paper sx={{ width: '500px', marginTop: '5px' }} ref={paperRef}>
+                <MenuList sx={{ padding: 0 }}>
+                    {isLoading ? (
+                        <MenuItem sx={{ alignItems: 'center', justifyContent: 'center' }}>
+                            <PulseLoader
+                                color="#ee4949"
+                                cssOverride={{}}
+                                margin={10}
+                                size={10}
+                                speedMultiplier={0.5}
+                            />
+                        </MenuItem>
+                    ) : (
+                        <>
+                            {!recentSearches.length ? (
+                                <></>
+                            ) : (
+                                <>
+                                    <Paper
+                                        sx={{
+                                            padding: '0 10px',
+                                            display: 'flex',
+                                            justifyContent: 'space-between',
+                                            alignItems: 'center',
+                                            borderBottomLeftRadius: 0,
+                                            borderBottomRightRadius: 0,
+                                            height: '40px',
+                                        }}
+                                    >
+                                        <Typography
+                                            variant="h4"
+                                            sx={{
+                                                fontWeight: 700,
+                                                fontSize: '16px',
+                                            }}
+                                        >
+                                            Lịch sử tìm kiếm
+                                        </Typography>
+                                        <Button size='small' endIcon={<DeleteOutlineIcon />} sx={{ color: 'inherit'}}>
+                                            Xóa tất cả
+                                        </Button>
+                                    </Paper>
+                                    {recentSearches.map((searchTerm, i) => (
+                                        <MenuItem
+                                            divider
+                                            key={i}
+                                            sx={{ alignItems: 'center', padding: '0px 10px' }}
+                                        >
+                                            <ListItemIcon>
+                                                <AccessTimeIcon />
+                                            </ListItemIcon>
+                                            <ListItemText onClick={() => getHistoryKey(searchTerm)}>
+                                                {searchTerm}
+                                            </ListItemText>
+                                            <IconButton
+                                                sx={{ backgroundColor: 'inherit !important' }}
+                                                onClick={() => removeItem(searchTerm)}
+                                            >
+                                                <CloseIcon />
+                                            </IconButton>
+                                        </MenuItem>
+                                    ))}
+                                    {currentProducts.length !== 0 && (
+                                        <Paper
+                                            sx={{
+                                                padding: '0 10px',
+                                                display: 'flex',
+                                                alignItems: 'center',
+                                                height: '40px',
+                                            }}
+                                        >
+                                            <Typography
+                                                variant="h4"
+                                                sx={{
+                                                    fontWeight: 700,
+                                                    fontSize: '16px',
+                                                }}
+                                            >
+                                                Sản phẩm gợi ý
+                                            </Typography>
+                                        </Paper>
+                                    )}
+                                    {currentProducts.map((product) => (
+                                        <MenuItem key={product.id} onClick={() => router.push(`/chi-tiet-san-pham/${product.id}`)}>
+                                            <Stack spacing={2} direction="row">
+                                                <Box>
+                                                    <Image
+                                                        src={product.image}
+                                                        alt={product.name}
+                                                        height={64}
+                                                        width={64}
+                                                    />
+                                                </Box>
+                                                <Stack
+                                                    sx={{
+                                                        width: '100%',
+                                                        paddingLeff: '10px',
+                                                    }}
+                                                    alignItems='flex-start'
+                                                    justifyContent='center'
+                                                    spacing={1}
+                                                >
+                                                    <Typography
+                                                        variant="h4"
+                                                        sx={{
+                                                            fontWeight: '600',
+                                                            fontSize: '16px',
+                                                        }}
+                                                    >
+                                                        {product.name}
+                                                    </Typography>
+                                                    <Box sx={{ display: 'flex', alignItems: 'flex-end', gap: '8px' }}>
+                                                        <Typography variant='h6' sx={{ fontWeight: 700, fontSize: '17px', color: '#ee4949' }}>
+                                                            {currencyFormat(product.price.sale)}
+                                                        </Typography>
+                                                        <Typography variant='h6' sx={{ fontWeight: 500, fontSize: '14px', color: '#777777', textDecoration: 'line-through' }}>
+                                                            {currencyFormat(product.price.base)}
+                                                        </Typography>
+                                                    </Box>
+                                                </Stack>
+                                            </Stack>
+                                        </MenuItem>
+                                    ))}
+                                </>
+                            )}
+                        </>
+                    )}
+                </MenuList>
+            </Paper>
+        </Popper>
+    );
+};
+
+export default CurrentSearches;

--- a/src/components/Common/Searching/RecentSearches.tsx
+++ b/src/components/Common/Searching/RecentSearches.tsx
@@ -1,0 +1,95 @@
+import React, { FC, useRef } from 'react';
+
+import { useOnClickOutside } from 'usehooks-ts';
+
+import Popper, { PopperProps } from '@mui/material/Popper';
+import Paper from '@mui/material/Paper';
+import MenuList from '@mui/material/MenuList';
+import MenuItem from '@mui/material/MenuItem';
+import ListItemIcon from '@mui/material/ListItemIcon';
+import ListItemText from '@mui/material/ListItemText';
+import IconButton from '@mui/material/IconButton';
+import Typography from '@mui/material/Typography';
+import AccessTimeIcon from '@mui/icons-material/AccessTime';
+import CloseIcon from '@mui/icons-material/Close';
+import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
+
+interface RecentSearchValueProps {
+    onClose(): void;
+    getHistoryKey(searched: string): void;
+    recentSearches: string[];
+    removeItem(searchTerm: string): void;
+}
+
+const RecentSearches: FC<RecentSearchValueProps & PopperProps> = ({
+    open,
+    anchorEl,
+    onClose,
+    getHistoryKey,
+    recentSearches,
+    removeItem,
+}) => {
+    const paperRef = useRef<HTMLDivElement>(null);
+
+    const el = anchorEl as HTMLElement;
+
+    useOnClickOutside(paperRef, onClose);
+    if (!anchorEl) return null;
+
+    return (
+        <Popper open={open} anchorEl={anchorEl} disablePortal placement="bottom-start">
+            <Paper sx={{ width: el.clientWidth, marginTop: '5px' }} ref={paperRef}>
+                <MenuList sx={{ padding: 0 }}>
+                    {!recentSearches.length ? (
+                        <></>
+                    ) : (
+                        <>
+                            <Paper
+                                sx={{
+                                    padding: '0 10px',
+                                    display: 'flex',
+                                    justifyContent: 'space-between',
+                                    alignItems: 'center',
+                                    borderBottomLeftRadius: 0,
+                                    borderBottomRightRadius: 0,
+                                }}
+                            >
+                                <Typography
+                                    variant="h4"
+                                    sx={{ fontWeight: 700, fontSize: '16px', color: '#777777' }}
+                                >
+                                    Lịch sử tìm kiếm
+                                </Typography>
+                                <IconButton sx={{ backgroundColor: 'inherit !important' }}>
+                                    <DeleteOutlineIcon />
+                                </IconButton>
+                            </Paper>
+                            {recentSearches.map((searchTerm, i) => (
+                                <MenuItem
+                                    divider
+                                    key={i}
+                                    sx={{ alignItems: 'center', padding: '0px 10px' }}
+                                >
+                                    <ListItemIcon>
+                                        <AccessTimeIcon />
+                                    </ListItemIcon>
+                                    <ListItemText onClick={() => getHistoryKey(searchTerm)}>
+                                        {searchTerm}
+                                    </ListItemText>
+                                    <IconButton
+                                        sx={{ backgroundColor: 'inherit !important' }}
+                                        onClick={() => removeItem(searchTerm)}
+                                    >
+                                        <CloseIcon />
+                                    </IconButton>
+                                </MenuItem>
+                            ))}
+                        </>
+                    )}
+                </MenuList>
+            </Paper>
+        </Popper>
+    );
+};
+
+export default RecentSearches;

--- a/src/components/Common/Searching/ResultsPage.tsx
+++ b/src/components/Common/Searching/ResultsPage.tsx
@@ -1,29 +1,48 @@
+'use client';
 
+import React, { FC } from 'react';
 
-import React, { FC, useEffect } from 'react'
+import Box from '@mui/material/Box';
+import Container from '@mui/material/Container';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
 
-import { useAppDispatch, useAppSelector } from '@store/store';
-import { Paging } from '@models/Common';
+import { ProductSearchingStatus } from '@interfaces/product';
+import { formatProductLabel, getMessage } from 'utils';
+import ResultsSection from './ResultsSection';
 
 interface SearchProps {
-    searchKey: string;
+    searchData: ProductSearchingStatus;
+    keyword: string;
 }
 
-const ResultsPage: FC<SearchProps> = ({ searchKey }) => {
-    const searchProduct = {
-        ...new Paging(),
-        searchKey: searchKey,
-    }
+const ResultsPage: FC<SearchProps> = async ({ searchData, keyword }) => {
+    const headMessage = getMessage(searchData.messageStatusCode, keyword, searchData.data?.totalRecord);
 
-    const dispatch = useAppDispatch();
-    const { products, isLoading } = useAppSelector((state) => state.product);
+    return (
+        <Box marginTop="24px">
+            <Container maxWidth="lg">
+                    <Stack spacing={3} alignItems="center" minHeight='60vh'>
+                        <Typography
+                            variant="h3"
+                            color="primary"
+                            sx={{
+                                fontSize: '18px',
+                                fontWeight: 500,
+                                '& span': {
+                                    fontWeight: 700,
+                                },
+                            }}
+                        >
+                            <div dangerouslySetInnerHTML={{ __html: headMessage}} />
+                        </Typography>
+                        {searchData.data !== null && (
+                            <ResultsSection currentData={formatProductLabel(searchData.data)} keyword={keyword} totalPage={searchData.data.totalPage} />
+                        )}
+                    </Stack>
+            </Container>
+        </Box>
+    );
+};
 
-    
-
-
-  return (
-    <div>ResultsPage</div>
-  )
-}
-
-export default ResultsPage
+export default ResultsPage;

--- a/src/components/Common/Searching/ResultsSection.tsx
+++ b/src/components/Common/Searching/ResultsSection.tsx
@@ -1,0 +1,71 @@
+'use client';
+
+import React, { ChangeEvent, FC, useState } from 'react';
+
+import { useAppDispatch, useAppSelector } from '@store/store';
+import { useSkipFirstRender } from '@hooks/useSkipFirstRender';
+import { getAllProduct } from '@store/slices/productSlice';
+
+import { Paging } from '@models/Common';
+import { ProductLabel } from '@interfaces/product';
+
+import Box from '@mui/material/Box';
+import SortingToolbarVSearch from './SortingToolbar-vSearch';
+import { formatProductLabel } from 'utils';
+import PaginationData from '../PaginationData/PaginationData';
+import LoadingSection from '../Display/LoadingSection';
+
+interface ResultsDataProps {
+    currentData: ProductLabel[];
+    keyword: string;
+    totalPage: number;
+}
+
+const ResultsSection: FC<ResultsDataProps> = ({ currentData, keyword, totalPage }) => {
+    const dispatch = useAppDispatch();
+    const { products, isLoading } = useAppSelector((state) => state.product);
+
+    const [searchProduct, setSearchProduct] = useState<Paging>({ ...new Paging(), keyword });
+    const [currentProducts, setCurrentProducts] = useState<ProductLabel[]>(currentData);
+
+    useSkipFirstRender(() => {
+        dispatch(getAllProduct(searchProduct));
+        
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [searchProduct]);
+
+    useSkipFirstRender(() => {
+        const formatProducts = formatProductLabel(products);
+
+        setCurrentProducts(formatProducts);
+    }, [products])
+
+    const handleChange = (event: ChangeEvent<unknown>, page: number) => {
+        setSearchProduct({
+            ...searchProduct,
+            page: page - 1,
+            keyword,
+        });
+    };
+
+    return (
+        <>
+            {isLoading ? (
+                <LoadingSection isLoading={isLoading} />
+            ) : (
+                <>
+                    <Box sx={{ width: '100%' }}>
+                        <SortingToolbarVSearch />
+                    </Box>
+                    <PaginationData 
+                        initialData={currentProducts}
+                        pagingData={{ page: searchProduct.page, totalPage }}
+                        handleChange={handleChange}
+                    />
+                </>
+            )}
+        </>
+    );
+};
+
+export default ResultsSection;

--- a/src/components/Common/Searching/SearchBar.tsx
+++ b/src/components/Common/Searching/SearchBar.tsx
@@ -1,0 +1,109 @@
+'use client';
+
+import React, { ChangeEvent, FC, useEffect, useState } from 'react';
+
+import { alpha, styled } from '@mui/material/styles';
+import Box from '@mui/material/Box';
+import InputBase, { InputBaseProps } from '@mui/material/InputBase';
+import IconButton from '@mui/material/IconButton';
+import Divider from '@mui/material/Divider';
+import SearchIcon from '@mui/icons-material/Search';
+import { Urlify } from 'utils';
+
+const StyledBox = styled(Box)(({ theme }) => ({
+    position: 'relative',
+    display: 'flex',
+    //justifyContent: 'center',
+    borderRadius: theme.shape.borderRadius,
+    backgroundColor: alpha(theme.palette.common.white, 0.15),
+    '&:hover': {
+        backgroundColor: alpha(theme.palette.common.white, 0.25),
+    },
+    padding: 0,
+    width: '100%',
+    [theme.breakpoints.up('sm')]: {
+        width: 'auto',
+    },
+}));
+
+const StyledInputBase = styled(InputBase)(({ theme }) => ({
+    color: 'inherit',
+    '& .MuiInputBase-input': {
+        padding: theme.spacing(1, 2),
+        width: '100%',
+        //transition: 'all .5s',
+        // [theme.breakpoints.up('sm')]: {
+        //     width: '12ch',
+        //     '&:focus': {
+        //         width: '20ch',
+        //     },
+        // },
+    },
+}));
+
+interface SearchValueProps {
+    // the outside components only needs to know if the searchbar form has been submitted
+    onSubmit(searchTerm: string): void;
+    defaultValue: string;
+    alreadyInputSomething(searkey: string): void;
+    handleLengthSituations(): void;
+    // add inputProps so that we can listen to onFocus / onBlur events if needed
+    inputProps: InputBaseProps;
+};
+
+const SearchBar: FC<SearchValueProps> = ({ onSubmit, defaultValue, alreadyInputSomething, handleLengthSituations, inputProps }) => {
+    const [searchTerm, setSearchTerm] = useState<string>('');
+    const [isError, setIsError] = useState<boolean>(false);
+
+    const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+        e.preventDefault();
+        setIsError(true);
+        const searchKey = e.target.value.trim();
+
+        if (searchKey.length > 0) {
+            setIsError(false);
+            alreadyInputSomething(searchKey);
+        }
+        if (searchKey === '') {
+            handleLengthSituations();
+        }
+        setSearchTerm(e.target.value);
+    }
+
+    useEffect(() => {
+        setSearchTerm(defaultValue);
+        if (defaultValue.length > 0) {
+            alreadyInputSomething(defaultValue);
+        }
+    }, [defaultValue]);
+
+    return (
+        <>
+            <StyledBox
+                component="form"
+                sx={{ border: isError ? '3px solid red' : 'none' }}
+                onSubmit={(e) => {
+                    e.preventDefault();
+                    if (!isError) {
+                        onSubmit(searchTerm);
+                    };
+                }}
+            >
+                <StyledInputBase 
+                    placeholder="Tìm kiếm..."
+                    inputProps={{ "aria-label": "search" }}
+                    value={searchTerm}
+                    onChange={handleChange}
+                    {...inputProps} 
+                />
+                <Divider light sx={{ height: 28, mx: 0.5 }} orientation="vertical" />
+                <IconButton type="submit" sx={{ p: '4px', color: 'inherit' }} aria-label="search">
+                    <SearchIcon />
+                </IconButton>
+            </StyledBox>
+        </>
+    );
+};
+
+export default SearchBar;
+

--- a/src/components/Common/Searching/SearchBarBox.tsx
+++ b/src/components/Common/Searching/SearchBarBox.tsx
@@ -1,0 +1,131 @@
+'use client';
+
+import React, { FocusEvent, useEffect, useRef, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { useRecentSearches } from '@hooks/useRecentSearches';
+
+import Box from '@mui/material/Box';
+import SearchBar from './SearchBar';
+import RecentSearches from './RecentSearches';
+import CurrentSearches from './CurrentSearches';
+
+import { ProductLabel } from '@interfaces/product';
+import { Paging } from '@models/Common';
+
+import { useAppDispatch } from '@store/store';
+import { getAllProduct } from '@store/slices/productSlice';
+import { Urlify } from 'utils';
+
+type ProductStatement = {
+    products: ProductLabel[];
+    isLoading: boolean;
+};
+
+const SearchBarBox = () => {
+    const router = useRouter();
+    const dispatch = useAppDispatch();
+
+    const { recentSearches, setRecentSearches } = useRecentSearches();
+    // track state for showing RecentSearches
+    const [openRecents, setOpenRecents] = useState<boolean>(false);
+    const [openCurrents, setOpenCurrents] = useState<boolean>(false);
+
+    const [value, setValue] = useState<string>('');
+
+    const [searchProduct, setSearchProduct] = useState<Paging>(new Paging());
+
+    const anchorEl = useRef<HTMLDivElement>(null);
+
+    const getHistoryKey = (historyKey: string) => {
+        setValue(historyKey);
+    };
+
+    const removeItem = (searchTerm: string) => {
+        setRecentSearches(recentSearches.filter((item) => item !== searchTerm));
+    };
+
+    const onInputSomething = (searchKey: string) => {
+        setSearchProduct({
+            ...new Paging(),
+            pageSize: 3,
+            keyword: searchKey,
+        });
+        setOpenRecents(false);
+        setOpenCurrents(true);
+    };
+
+    const handleSubmit = (searchTerm: string) => {
+        const url = 'tim-kiem?search=' + encodeURIComponent(Urlify(searchTerm));
+        router.push(url);
+        
+        // add to push recent searches after every search
+        if (!recentSearches.includes(searchTerm.trim())) {
+            setRecentSearches([searchTerm.trim(), ...recentSearches]);
+        }
+        setOpenCurrents(false);
+        setValue('');
+    };
+
+    useEffect(() => {
+        if (searchProduct.keyword) {
+            const timer = setTimeout(() => {
+                console.log(searchProduct);
+                dispatch(getAllProduct(searchProduct));
+            }, 600);
+
+            return () => clearTimeout(timer);
+        }
+
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [searchProduct]);
+
+    return (
+        <Box
+            sx={{
+                display: { xs: 'none', lg: 'flex' },
+                width: '260px',
+                justifyContent: 'center',
+            }}
+            ref={anchorEl}
+        >
+            <SearchBar
+                onSubmit={handleSubmit}
+                defaultValue={value}
+                inputProps={{
+                    onFocus: (e) => {
+                        if (e.target.value.trim().length === 0) {
+                            setOpenRecents(true);
+                        }
+                    },
+                }}
+                alreadyInputSomething={onInputSomething}
+                handleLengthSituations={() => {
+                    setOpenRecents(true);
+                    setOpenCurrents(false);
+                }}
+            />
+            <RecentSearches
+                open={openRecents}
+                anchorEl={anchorEl.current}
+                onClose={() => {
+                    setOpenRecents(false);
+                }}
+                recentSearches={recentSearches.slice(0, 6)}
+                removeItem={removeItem}
+                getHistoryKey={getHistoryKey}
+            />
+            <CurrentSearches
+                open={openCurrents}
+                anchorEl={anchorEl.current}
+                onClose={() => {
+                    setOpenCurrents(false);
+                }}
+                recentSearches={recentSearches.slice(0, 3)}
+                removeItem={removeItem}
+                getHistoryKey={getHistoryKey}
+            />
+        </Box>
+    );
+};
+
+export default SearchBarBox;

--- a/src/components/Common/Searching/SortingToolbar-vSearch.tsx
+++ b/src/components/Common/Searching/SortingToolbar-vSearch.tsx
@@ -2,13 +2,14 @@
 
 import React, { useState, MouseEvent, FC } from 'react';
 
+import styles from '@styles/components/brands.module.scss';
+
 import Box from '@mui/material/Box';
 import Stack from '@mui/material/Stack';
 import ToggleButton from '@mui/material/ToggleButton';
 import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
 import Typography from '@mui/material/Typography';
 import { styled } from '@mui/material';
-import { Percent, Visibility } from '@mui/icons-material';
 import { Ascending, Descending } from '@components/svgs';
 
 const ToggleButtonStyled = styled(ToggleButton)(({ theme }) => ({
@@ -37,12 +38,8 @@ const ToggleButtonStyled = styled(ToggleButton)(({ theme }) => ({
     },
 }));
 
-interface ToolbarProps {
-    className: string;
-}
-
-const SortingToolbar: FC<ToolbarProps> = ({ className }) => {
-    const [sortByTag, setSortByTag] = useState('popular');
+const SortingToolbarVSearch = () => {
+    const [sortByTag, setSortByTag] = useState('relevant');
 
     const handleSortByTag = (event: MouseEvent<HTMLElement>, newSorting: string) => {
         setSortByTag(newSorting);
@@ -61,7 +58,7 @@ const SortingToolbar: FC<ToolbarProps> = ({ className }) => {
                     <Typography variant="h5" fontWeight={600} fontSize={18}>
                         Sắp xếp theo
                     </Typography>
-                    <Box className={className}>
+                    <Box className={styles.list_brands}>
                         <ToggleButtonGroup
                             sx={{
                                 display: 'grid',
@@ -79,6 +76,9 @@ const SortingToolbar: FC<ToolbarProps> = ({ className }) => {
                             }}
                             {...sortByTagControl}
                         >
+                            <ToggleButtonStyled value="relevant" key="relevant">
+                                Liên quan
+                            </ToggleButtonStyled>
                             <ToggleButtonStyled value="ascending" key="ascending">
                                 <Descending style={{ fontSize: '20px', marginRight: '5px' }} />
                                 Giá Cao - Thấp
@@ -86,14 +86,6 @@ const SortingToolbar: FC<ToolbarProps> = ({ className }) => {
                             <ToggleButtonStyled value="descending" key="descending">
                                 <Ascending style={{ fontSize: '20px', marginRight: '5px' }} />
                                 Giá Thấp - Cao
-                            </ToggleButtonStyled>
-                            <ToggleButtonStyled value="hot-promo" key="hot-promo">
-                                <Percent sx={{ fontSize: '20px', marginRight: '5px' }} />
-                                Khuyến mãi hot
-                            </ToggleButtonStyled>
-                            <ToggleButtonStyled value="popular" key="popular">
-                                <Visibility sx={{ fontSize: '20px', marginRight: '5px' }} />
-                                Xem nhiều
                             </ToggleButtonStyled>
                         </ToggleButtonGroup>
                     </Box>
@@ -103,4 +95,4 @@ const SortingToolbar: FC<ToolbarProps> = ({ className }) => {
     );
 };
 
-export default SortingToolbar;
+export default SortingToolbarVSearch;

--- a/src/components/Navigation/HeaderClient.tsx
+++ b/src/components/Navigation/HeaderClient.tsx
@@ -1,13 +1,12 @@
 'use client';
 
-import Image from 'next/image';
 import React, { useState } from 'react';
+import Image from 'next/image';
+
 import AccountCircleIcon from '@mui/icons-material/AccountCircle';
 import {
     AppBar,
     Box,
-    CssBaseline,
-    Divider,
     Drawer,
     IconButton,
     Toolbar,
@@ -20,7 +19,7 @@ import {
 import { Menu as MenuIcon, ShoppingCart as ShoppingCartIcon } from '@mui/icons-material';
 import SearchIcon from '@mui/icons-material/Search';
 import { useTheme } from '@mui/material/styles';
-import { MenuComponent, SearchComponent } from '@components/Form';
+import { MenuComponent } from '@components/Form';
 import { DRAWER_WIDTH, NAV_ITEMS } from '@constants/NavContants';
 import { DrawerLayout } from '@components/Layout';
 import Modal from '@mui/material/Modal';
@@ -28,8 +27,9 @@ import TextField from '@mui/material/TextField';
 import Autocomplete from '@mui/material/Autocomplete';
 import styles from 'styles/components/button.module.scss';
 import { useAppDispatch, useAppSelector } from '@store/store';
-import { logOut } from '@store/slices/authSlice';
 import { signIn, useSession, signOut } from 'next-auth/react';
+
+import SearchBarBox from '@components/Common/Searching/SearchBarBox';
 
 interface Props {
     window?: () => Window;
@@ -37,7 +37,7 @@ interface Props {
 
 export const HeaderClient = (props: Props) => {
     const { data: session } = useSession();
-    console.log({session});
+    console.log({ session });
     const dispatch = useAppDispatch();
     // const { user } = useAppSelector((state) => state.auth);
     const theme = useTheme();
@@ -137,9 +137,7 @@ export const HeaderClient = (props: Props) => {
                         gap={5}
                         sx={{ justifyContent: { xs: 'space-between' } }}
                     >
-                        <Box sx={{ display: { xs: 'none', lg: 'block' } }}>
-                            <SearchComponent />
-                        </Box>
+                        <SearchBarBox />
                         <Box
                             sx={{
                                 display: { xs: 'none', sm: 'none', md: 'none', lg: 'flex' },

--- a/src/components/Theme/MuiCustomTheme.ts
+++ b/src/components/Theme/MuiCustomTheme.ts
@@ -39,6 +39,11 @@ declare module '@mui/material/styles' {
 }
 
 export const theme: Theme = createTheme({
+    palette: {
+        primary: {
+            main: '#ee4949',
+        }
+    },
     primary: {
         main: '#ee4949',
         darker: '#eb2525',

--- a/src/constants/errorCode.ts
+++ b/src/constants/errorCode.ts
@@ -1,0 +1,37 @@
+import { ErrorLabel } from "@interfaces/error";
+
+export const FOUND_CODE = 'found';
+
+export const NOTFOUND_ERROR_CODE = 'notFoundError';
+
+export const SERVER_ERROR_CODE = 'serverError';
+
+export const MAP_STATUS_CODE = new Map<string, ErrorLabel>([
+    [FOUND_CODE, {
+        code: FOUND_CODE,
+        message: 'Tìm thấy'
+    },],
+    [NOTFOUND_ERROR_CODE, {
+        code: NOTFOUND_ERROR_CODE,
+        message: 'Không tìm thấy sản phẩm nào cho từ khóa'
+    },],
+    [SERVER_ERROR_CODE, {
+        code: SERVER_ERROR_CODE,
+        message: 'Có lỗi xảy ra. Xin vui lòng thử lại sau'
+    }],
+]);
+
+export const CUSTOM_STATUS_CODE = [
+    {
+        code: FOUND_CODE,
+        message: 'Tìm thấy'
+    },
+    {
+        code: NOTFOUND_ERROR_CODE,
+        message: 'Không tìm thấy sản phẩm nào cho từ khóa'
+    },
+    {
+        code: SERVER_ERROR_CODE,
+        message: 'Có lỗi xảy ra. Xin vui lòng thử lại sau'
+    }
+]

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,3 +1,4 @@
 export * from './NavContants';
 export * from './PhoneConstant';
 export * from './Services';
+export * from './errorCode';

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,2 +1,4 @@
 export * from './useAxios';
 export * from './useRefreshToken';
+export * from './useRecentSearches';
+export * from './useSkipFirstRender';

--- a/src/hooks/useRecentSearches.ts
+++ b/src/hooks/useRecentSearches.ts
@@ -1,0 +1,13 @@
+import { useLocalStorage } from "usehooks-ts";
+
+export const useRecentSearches = () => {
+  const [recentSearches, setRecentSearches] = useLocalStorage<string[]>(
+    "recent-searches",
+    []
+  );
+
+  return {
+    recentSearches,
+    setRecentSearches,
+  };
+};

--- a/src/hooks/useSkipFirstRender.ts
+++ b/src/hooks/useSkipFirstRender.ts
@@ -1,0 +1,17 @@
+'client';
+
+import { useEffect, useRef } from "react";
+
+export const useSkipFirstRender = (callback: () => void, dependencies: any) => {
+  const firstRenderRef = useRef(true);
+
+  useEffect(() => {
+    if (!firstRenderRef.current) {
+      callback();
+    }
+  }, [...dependencies]);
+
+  useEffect(() => {
+    firstRenderRef.current = false;
+  }, []);
+};

--- a/src/interfaces/error.ts
+++ b/src/interfaces/error.ts
@@ -1,0 +1,4 @@
+export interface ErrorLabel {
+    code: string;
+    message: string;
+}

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -1,3 +1,4 @@
 export * from './form';
 export * from './auth';
 export * from './product';
+export * from './error';

--- a/src/interfaces/product.ts
+++ b/src/interfaces/product.ts
@@ -1,4 +1,4 @@
-import { PriceModel } from "@models/Product";
+import { PriceModel, ProductData } from "@models/Product";
 
 export interface CategorySelecting {
     key: string;
@@ -25,4 +25,9 @@ export interface VariantInfo {
     color: string;
     price: PriceModel;
     isSelectedColor: boolean;
+}
+
+export interface ProductSearchingStatus {
+    data: ProductData | null;
+    messageStatusCode: string;
 }

--- a/src/services/Instance.ts
+++ b/src/services/Instance.ts
@@ -11,8 +11,6 @@ const instance: AxiosInstance = axios.create({
     },
 });
 
-
-
 instance.interceptors.request.use(
     (config) => {
         const accessToken = getAccessToken();

--- a/src/services/InstancePublic.ts
+++ b/src/services/InstancePublic.ts
@@ -1,0 +1,12 @@
+import axios, { AxiosInstance } from 'axios';
+import { API_ENDPOINT } from '@constants/Services';
+
+const instancePublic: AxiosInstance = axios.create({
+    baseURL: API_ENDPOINT,
+    //timeout: 10000,
+    headers: {
+        'Content-Type': 'application/json',
+    }
+});
+
+export default instancePublic;

--- a/src/services/ProductService.ts
+++ b/src/services/ProductService.ts
@@ -1,6 +1,8 @@
 import { PRODUCTS_ENDPOINT } from '@constants/Services';
 import instance from './Instance';
-import { PagingProduct } from '@models/Product';
+import { PagingProduct, ProductData } from '@models/Product';
+
+import instancePublic from './InstancePublic';
 
 export const getProducts = (payload: PagingProduct) => {
     const { page, pageSize, keyword } = payload;
@@ -11,6 +13,17 @@ export const getProducts = (payload: PagingProduct) => {
     }
 
     return instance.get<PagingProduct>(url);
+};
+
+export const getProductsPublic = (payload: PagingProduct) => {
+    const { page, pageSize, keyword } = payload;
+    let url = `${PRODUCTS_ENDPOINT}?page=${page + 1}&pageSize=${pageSize}&select_type=only_active`;
+
+    if (keyword) {
+        url += `&keyword=${keyword}`;
+    }
+
+    return instancePublic.get<ProductData>(url);
 };
 
 export const getProductById = (id: string, isDetails?: boolean) => {

--- a/src/utils/get-products.ts
+++ b/src/utils/get-products.ts
@@ -1,0 +1,16 @@
+import { cache } from 'react';
+
+import { getProductsPublic } from '@services/ProductService';
+import { PagingProduct } from '@models/Product';
+import { Paging } from '@models/Common';
+
+export const revalidate = 3600; // revalidate the data at most every hour
+
+export const getProductsCustom = cache(async (keyword: string) => {
+    const searchProduct: PagingProduct = {
+        ...new Paging(),
+        keyword,
+    };
+    const { data } = await getProductsPublic(searchProduct);
+    return data;
+})

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,9 +1,12 @@
 import { ProductStatus } from '@constants/enum';
 import { IUser } from '@interfaces/auth';
 import jwtDecode, { JwtPayload } from 'jwt-decode';
-import { ImageModel } from '@models/Product';
+import { ImageModel, ProductData } from '@models/Product';
 import { AttributeDynamics } from '@models/Attribute';
 import { VariantStorage } from '@interfaces/product';
+import { FOUND_CODE, MAP_STATUS_CODE, NOTFOUND_ERROR_CODE, SERVER_ERROR_CODE } from '@constants/errorCode';
+
+export * from './get-products';
 
 // get information from local storage
 export const getCurrentUserId = () => {
@@ -167,6 +170,19 @@ export const currencyFormat = (price: number | null): string => {
     return formattedIntegerPart;
 };
 
+// format products data list
+export const formatProductLabel = (products: ProductData) => {
+    return products.data.map((product) => {
+        return {
+            id: product._id ?? '',
+            name: product.name ?? '',
+            category: product.category?.name ?? '',
+            price: product.variations[0].price,
+            image: getThumbnail(product.generalImages),
+        };
+    });
+}
+
 //get attribute from product details
 export const getSingleAttribute = (attributes: AttributeDynamics[], type: string) => {
     const specificAttribute = attributes.filter((attribute) => attribute.k === type).shift();
@@ -206,4 +222,26 @@ export const sortByCustomOrder = (arr: VariantStorage[]) => {
     };
 
     return arr.slice().sort((a, b) => (customOrder[a.storage] || 0) - (customOrder[b.storage] || 0));
+}
+
+//Urlify a given string 
+export const Urlify = (str: string) => {
+    return encodeURI(str.trim());
+}
+
+//Render message when searching products 
+export const getMessage = (messageStatusCode: string, keyword: string, totalRecord?: number) => {
+    let message = ''
+    switch (messageStatusCode) {
+        case FOUND_CODE: 
+            message = `Tìm thấy <span>${totalRecord}</span> sản phẩm cho từ khóa <span>'${keyword}'</span>`;
+            break;
+        case NOTFOUND_ERROR_CODE: 
+            message = MAP_STATUS_CODE.get(NOTFOUND_ERROR_CODE)!.message + ` <span>'${keyword}'</span>`;
+            break;
+        case SERVER_ERROR_CODE:
+            message = MAP_STATUS_CODE.get(SERVER_ERROR_CODE)!.message;
+    }
+
+    return message;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4569,6 +4569,11 @@ use-sync-external-store@^1.0.0:
   resolved "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz"
   integrity sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==
 
+usehooks-ts@^2.9.1:
+  version "2.9.1"
+  resolved "https://registry.yarnpkg.com/usehooks-ts/-/usehooks-ts-2.9.1.tgz#953d3284851ffd097432379e271ce046a8180b37"
+  integrity sha512-2FAuSIGHlY+apM9FVlj8/oNhd+1y+Uwv5QNkMQz1oSfdHk4PXo1qoCw9I5M7j0vpH8CSWFJwXbVPeYDjLCx9PA==
+
 uuid@^8.3.2:
   version "8.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"


### PR DESCRIPTION
A lots more to go with this, btw this is first commit of 'searching functionality'

- I handled searching bar to fetch products on user input by client-side catching keyword after user stop inputting
- For searching results page, this will be a server-side fetching first, and when user switch to other pages, we'll re-render it using client-side fetching, I done this by using a custom hook to skip first initial render of useEffect hook. I don't know is it a good way to go?